### PR TITLE
CODICE-2 Added curly braces to timeout clause

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,11 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                timeout(time: 20, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES') {
                     withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                         sh 'mvn clean install'
                     }
+                }
             }
         }
         /*


### PR DESCRIPTION
This allows the body of the Build stage to be read in Jenkins.

@clockard @LinkMJB @shaundmorris @austinsteffes @garrettfreibott @ahoffer @ricklarsen 