### PR TITLE
CODICE-2 Added scm checkout to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,9 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                retry(3) {
+                    checkout scm
+                }
                 timeout(time: 20, unit: 'MINUTES') {
                     withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                         sh 'mvn clean install'


### PR DESCRIPTION
Jenkins tries to run `mvn clean install` in an empty directory. A checkout is needed to ensure the latest changes are present and able to be built.